### PR TITLE
Fix GTSinger url

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Visit our [demo page](https://aaronz345.github.io/TCSingerDemo/) for audio sampl
 ## News
 - 2024.12: We released the checkpoints of TCSinger!
 - 2024.11: We released the code of TCSinger!
-- 2024.09: We released the full dataset of [GTSinger](https://github.com/GTSinger)!
+- 2024.09: We released the full dataset of [GTSinger](https://github.com/AaronZ345/GTSinger)!
 - 2024.09: TCSinger is accepted by EMNLP 2024!
 
 ## Key Features


### PR DESCRIPTION
## Sourcery 总结

文档：
- 修正 README 中 GTSinger 数据集的 URL，使其使用正确的 GitHub 路径

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Correct the GTSinger dataset URL in README to use the proper GitHub path

</details>